### PR TITLE
Handle relative URLs in API response

### DIFF
--- a/src/components/story.tsx
+++ b/src/components/story.tsx
@@ -9,7 +9,7 @@ const Story: Component<{ story: IStory }> = (props) => {
       <span class="score">{props.story.points}</span>
       <span class="title">
         <Show
-          when={props.story.url}
+          when={props.story.url && !props.story.url?.startsWith?.('item?id=')}
           fallback={<Link href={`/item/${props.story.id}`}>{props.story.title}</Link>}
         >
           <a href={props.story.url} target="_blank" rel="noreferrer">


### PR DESCRIPTION
Clicking on the title for an Ask story doesn't work because it's trying to get a URL of `item?id=1234` or similar, which I assume comes from HN itself, instead of `item/1234`, which is required for local path and the corresponding API request.